### PR TITLE
completion of translations

### DIFF
--- a/languages/de.php
+++ b/languages/de.php
@@ -1,8 +1,9 @@
 <?php
 return array(
-	'link-field.url'   => 'URL',
-	'link-field.file' => 'Datei',
-	'link-field.page' => 'Seite',
-	'link-field.email' => 'E-Mail',
-	'link-field.change' => 'Link-Typ ändern'
+	'link-field.change'		=> 'Link-Typ ändern',
+	'link-field.email'		=> 'E-Mail',
+	'link-field.file'		=> 'Datei',
+	'link-field.page'		=> 'Seite',
+	'link-field.phone'		=> 'Telefon',
+	'link-field.url'		=> 'URL'
 );

--- a/languages/en.php
+++ b/languages/en.php
@@ -1,7 +1,9 @@
 <?php
 return array(
-	'link-field.url'   => 'URL',
-	'link-field.page' => 'Page',
-	'link-field.email' => 'Email',
-	'link-field.change' => 'Change link type'
+	'link-field.change'		=> 'Change link type',
+	'link-field.email'		=> 'Email',
+	'link-field.file'		=> 'File',
+	'link-field.page'		=> 'Page',
+	'link-field.phone'		=> 'Phone',
+	'link-field.url'		=> 'URL'
 );


### PR DESCRIPTION
There were no translation strings for "Phone" in DE and "Phone", "File" in EN. Fixed that.