### PR TITLE
toHref(): correct format for tel links

### DIFF
--- a/index.php
+++ b/index.php
@@ -110,6 +110,7 @@ Kirby::plugin('medienbaecker/link', [
                     $href .= "mailto:";
                 }
                 if($type == "phone") {
+                    $link = str::replace($link, array(' ', '/', '-', '.'), '');
                     $href .= "tel:";
                 }
                 if($type == "page" AND $linkPage = page($link)) {


### PR DESCRIPTION
tel-Links shouldn't contain spaces, brackets, slashes, dots. Modification of toHref-method to remove these.