### PR TITLE
Add toHtml() support for other field types

### DIFF
--- a/index.php
+++ b/index.php
@@ -103,8 +103,21 @@ Kirby::plugin('medienbaecker/link', [
     'fieldMethods' => [
         'toHref' => function ($field) {
             if($field->isNotEmpty()) {
-                $type = $field->yaml()["type"];
-                $link = $field->yaml()["link"];
+                $data = $field->yaml();
+
+                if (!empty($data["type"]) AND !empty($data["link"])) {
+                    $type = $data["type"];
+                    $link = $data["link"];
+                } else if (!empty($data[0])) {
+                    // Fields like "link: https://example.com" are returned as
+                    // an array with the first element holding the value. This
+                    // adds support for fields of type `url` or `text` that
+                    // are supposed to be links.
+                    return $data[0];
+                } else {
+                    return "";
+                }
+
                 $href = "";
                 if($type == "email"){
                     $href .= "mailto:";


### PR DESCRIPTION
With this change, it'll be easier to incorporate the plugin. For example, I was using fields with type `url` everywhere and once I started using `toHtml()` I began to get errors for undefined index "type" and "link". Besides, the `$field->yaml()` function was called twice, which was redundant.

With this, you can use `toHtml()` on fields of type `url` and `text` as well.

If no valid value can be found, it will simply return a blank value. You'll know the link is broken/missing when it leads you nowhere.